### PR TITLE
Make xmppench work with latest upstream Swiften

### DIFF
--- a/BenchmarkNetworkFactories.cpp
+++ b/BenchmarkNetworkFactories.cpp
@@ -7,6 +7,7 @@
 #include "BenchmarkNetworkFactories.h"
 
 #include <Swiften/Crypto/PlatformCryptoProvider.h>
+#include <Swiften/IDN/IDNConverter.h>
 #include <Swiften/IDN/PlatformIDNConverter.h>
 #include <Swiften/Network/BoostConnectionFactory.h>
 #include <Swiften/Network/BoostConnectionServerFactory.h>
@@ -76,8 +77,8 @@ Swift::NetworkEnvironment* BenchmarkNetworkFactories::getNetworkEnvironment() co
 }
 
 Swift::IDNConverter* BenchmarkNetworkFactories::getIDNConverter() const {
-	static Swift::IDNConverter* idn = Swift::PlatformIDNConverter::create();
-	return idn;
+	static auto idn = Swift::PlatformIDNConverter::create();
+	return idn.get();
 }
 
 Swift::CryptoProvider* BenchmarkNetworkFactories::getCryptoProvider() const {

--- a/BenchmarkNetworkFactories.h
+++ b/BenchmarkNetworkFactories.h
@@ -7,7 +7,7 @@
 #pragma once
 #define private public // FIXME
 #include <Swiften/EventLoop/BoostASIOEventLoop.h>
-#define private private
+#undef private
 #include <Swiften/Network/NetworkFactories.h>
 #include <Swiften/TLS/PlatformTLSFactories.h>
 

--- a/LatencyWorkloadBenchmark.cpp
+++ b/LatencyWorkloadBenchmark.cpp
@@ -14,7 +14,9 @@
 #include "IdleSession.h"
 
 LatencyWorkloadBenchmark::LatencyWorkloadBenchmark(std::vector<Swift::NetworkFactories*> networkFactories, AccountDataProvider* accountProvider, Options& opt) : networkFactories(networkFactories), accountProvider(accountProvider), opt(opt), sessionsReadyToBenchmark(0) {
-	std::cout << "Creating sessions...";
+	constexpr int dotFrequency = 500;
+	std::cout << "Creating sessions";
+	std::cout.flush();
 
 	// create active sessions
 	for (int i = 0; i < opt.noOfActiveSessions / 2; ++i) {
@@ -25,6 +27,10 @@ LatencyWorkloadBenchmark::LatencyWorkloadBenchmark(std::vector<Swift::NetworkFac
 		activePair->onBenchmarkEnd.connect(boost::bind(&LatencyWorkloadBenchmark::handleBenchmarkEnd, this));
 		activeSessionPairs.push_back(activePair);
 		sessionsToActivate.push_back(activePair);
+		if (i % dotFrequency == 0) {
+			std::cout << ".";
+			std::cout.flush();
+		}
 	}
 
 	// create idle sessions
@@ -34,17 +40,26 @@ LatencyWorkloadBenchmark::LatencyWorkloadBenchmark(std::vector<Swift::NetworkFac
 		idleSession->onDoneBenchmarking.connect(boost::bind(&LatencyWorkloadBenchmark::handleBenchmarkSessionDone, this, idleSession));
 		idleSessions.push_back(idleSession);
 		sessionsToActivate.push_back(idleSession);
+		if (i % dotFrequency == 0) {
+			std::cout << ".";
+			std::cout.flush();
+		}
 	}
 
-	std::cout << "done." << std::endl;
-	std::cout << "Preparing sessions...";
+	std::cout << " done." << std::endl;
+	std::cout << "Preparing sessions";
 	std::cout.flush();
 
 	nextActivateSession = sessionsToActivate.begin();
 	for (size_t n = 0; n < opt.parallelLogins && n < sessionsToActivate.size(); ++n) {
 		(*nextActivateSession)->start();
 		++nextActivateSession;
+		if (n % dotFrequency == 0) {
+			std::cout << ".";
+			std::cout.flush();
+		}
 	}
+	std::cout << " done." << std::endl;
 }
 
 LatencyWorkloadBenchmark::~LatencyWorkloadBenchmark() {

--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,7 @@
 // #include <Swiften/EventLoop/SimpleEventLoop.h>
 #define private public // FIXME
 #include <Swiften/EventLoop/BoostASIOEventLoop.h>
-#define private private
+#undef private
 #include <Swiften/JID/JID.h>
 #include <Swiften/Network/BoostNetworkFactories.h>
 
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
 	std::vector<BoostASIOEventLoop*> eventLoops;
 	std::vector<NetworkFactories*> networkFactories;
 
-	for (int n = 0; n < jobs; ++n) {
+	for (size_t n = 0; n < jobs; ++n) {
 		BoostASIOEventLoop* eventLoop = new BoostASIOEventLoop(std::make_shared<boost::asio::io_service>());
 		NetworkFactories* factory;
 		//if (jobs > 1) {


### PR DESCRIPTION
The API for Swift::PlatformIDNConverter::create changed, updated the
invocation to build again.  A re-define of private caused build
failures on Debian 9.

Improves the output during setup to give a little more sense of
progress.

Test-Information:

Tested newly built xmppench against an XMPP server.